### PR TITLE
Disable automerge in upgrade-provider to match upstream

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -89,7 +89,9 @@ jobs:
           kind: provider
           email: bot@pulumi.com
           username: pulumi-bot
-          automerge: true
+          # Disabled to match the upstream terraform-provider-formal, where
+          # automerge is off and upgrade PRs are merged manually.
+          automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: true
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,17 @@ build, then open the PR yourself.
 > GitHub App, which aren't available to this repo. Running the CLI locally is the equivalent
 > that actually works for us.
 
+#### Automatic upgrade PRs (cron)
+
+`upgrade-provider.yml` also runs on a **daily cron (3 AM UTC)**: it checks for a new upstream
+Formal release and, if there is one, runs the `upgrade-provider` CLI and **opens a PR** with the
+regenerated schema/SDKs for you to review and merge. You can also trigger it on-demand from the
+Actions tab ("Run workflow"), optionally pinning a `version`.
+
+`automerge` is set to `false` (matching the upstream `terraform-provider-formal`, where upgrade
+PRs are merged manually). Note that `upgrade-provider.yml` is ci-mgmt-generated, so `make ci-mgmt`
+resets `automerge` back to `true` — re-set it to `false` afterward.
+
 #### Doing it manually
 
 If `upgrade-provider` is broken or unavailable, do the upstream-provider bump by hand:


### PR DESCRIPTION
Sets `automerge: false` in `upgrade-provider.yml` so the daily cron opens upgrade PRs for manual review/merge, matching the upstream `terraform-provider-formal` (where upgrade PRs are merged manually).

Also documents the cron behavior in AGENTS.md, including the note that `make ci-mgmt` resets `automerge` back to `true` and must be re-set afterward.

Context: the daily cron was previously failing because the `kind/enhancement` label it needs to open a tracking issue didn't exist in this repo; that label has since been created.