### PR TITLE
ci: authenticate upgrade-provider via GitHub App token

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -48,6 +48,19 @@ jobs:
       - id: esc-secrets
         name: Map environment to ESC outputs
         uses: ./.github/actions/esc-action
+      # Local patch (not from ci-mgmt): mint a token from the Formal GitHub App.
+      # The default GITHUB_TOKEN is blocked from createPullRequest and its PRs don't
+      # trigger CI; an App installation token can do both. Requires vars.APP_ID +
+      # secrets.APP_PRIVATE_KEY, and the App installed on this repo with
+      # contents/pull-requests/issues/workflows: write. `make ci-mgmt` will drop this
+      # step + revert the GH_TOKEN lines below — re-apply afterward.
+      - name: Create GitHub App token
+        id: app-auth
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Setup mise
         uses: blampe/mise-action@blampe/plugins
         env:
@@ -73,7 +86,7 @@ jobs:
         run: upgrade-provider "$REPO" --kind=check-upstream-version
         env:
           REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}
         shell: bash
       - name: Calculate target version
         id: target_version
@@ -95,4 +108,4 @@ jobs:
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: true
         env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}


### PR DESCRIPTION
## What

Wires the daily `upgrade-provider.yml` workflow to authenticate with the Formal **GitHub App** instead of the default `GITHUB_TOKEN`.

Adds an `actions/create-github-app-token` step (using `vars.APP_ID` + `secrets.APP_PRIVATE_KEY`) and swaps both `GH_TOKEN` references to the resulting installation token.

## Why

The cron has been failing every night at the PR-creation step:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

The default `GITHUB_TOKEN` is blocked from `createPullRequest`, and even if allowed, its PRs don't trigger CI. An App installation token does both — so this unblocks automatic upgrade PRs without loosening the repo-wide "Allow GitHub Actions to create and approve pull requests" setting.

## Prerequisites before this works

- [x] `vars.APP_ID` set
- [x] `secrets.APP_PRIVATE_KEY` set
- [ ] **Formal GitHub App installed on this repo** with `contents`, `pull-requests`, `issues`, `workflows` = write

## Notes

- `automerge` stays `false` (merged in #d17f422) — this only fixes PR *creation*; merges remain manual.
- `upgrade-provider.yml` is ci-mgmt-generated, so `make ci-mgmt` will revert this. The added step has a comment flagging it as a local patch to re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)