### PR TITLE
ci: override Node to 24.18.0 to fix nodejs SDK build

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,3 +3,9 @@
 # to an old syntax version. Use `golangci-lint migrate` to update it.
 golangci-lint = "2.10.1"
 "go:github.com/pulumi/upgrade-provider" = "latest"
+# Override the ci-mgmt-pinned Node (20.19.5) — @pulumi/pulumi >= 3.250.0 requires
+# node >= 22, so the nodejs SDK build fails on 20. We only override the version
+# here rather than adopting the boilerplate's .config/mise.toml wholesale, because
+# that newer config also switches to `{{ env.GO_VERSION_MISE }}` syntax which the
+# pinned mise (2026.1.1) can't render (the var isn't set at parse time).
+node = "24.18.0"


### PR DESCRIPTION
## What
Add `node = "24.18.0"` to the repo-owned root `mise.toml`.

## Why
The nodejs SDK build fails on all branches:

```
error @pulumi/pulumi@3.250.0: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.5"
```

`@pulumi/pulumi` >= 3.250.0 raised `engines.node` to >= 22, but `.config/mise.toml` pins Node `20.19.5`.

## Why not just adopt the boilerplate's `.config/mise.toml`?
First attempt did that — it bumps Node to 24.18.0 but **also** switches go/pulumi to the newer `{{ env.GO_VERSION_MISE }}` syntax, which the pinned mise (`2026.1.1`) can't render:

```
mise ERROR Variable `env.GO_VERSION_MISE` not found in context
```

The old `get_env(name=..., default='latest')` form tolerates the var being unset; the bare `env.X` form doesn't. So we keep `.config/mise.toml` as-is and override only the Node version in the root `mise.toml` (same place the `golangci-lint` pin lives). Touches one line, survives `make ci-mgmt`.

Not caused by any local change — broke when Pulumi published 3.250.0; `v1.2.0` built fine before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)